### PR TITLE
Ao release v.0.3.2

### DIFF
--- a/src/r5py_ao/__init__.py
+++ b/src/r5py_ao/__init__.py
@@ -2,7 +2,7 @@
 
 """Python wrapper for the R5 routing analysis engine."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from .r5 import (
     DetailedItinerariesComputer,

--- a/src/r5py_ao/util/classpath.py
+++ b/src/r5py_ao/util/classpath.py
@@ -17,8 +17,8 @@ from .warnings import R5pyWarning
 
 
 # update these to use a newer R5 version if no R5 available locally
-R5_JAR_URL = "https://github.com/AccessibilityObservatory/r5/releases/download/v6.9-ao2/r5-v6.9-ao2-all.jar"
-R5_JAR_SHA256 = "088becfeb538176bf5ebda269ffe01ff5857201cedfff46f9734a8feb10bd529"
+R5_JAR_URL = "https://github.com/AccessibilityObservatory/r5/releases/download/v6.9-ao3/r5-v6.9-ao3-all.jar"
+R5_JAR_SHA256 = "4dcd97f427cc699d6f8ae1d4c2b63540a11a64b3ccf9fe3818361dfcfd85d1e2"
 # ---
 
 


### PR DESCRIPTION
Drafted a pre-release for version 0.3.2, modifying path to read the latest r5 jar https://github.com/AccessibilityObservatory/r5py-ao/releases/tag/v0.3.2

All tests are successful, able to install and run calculation with the latest r5 jar. 